### PR TITLE
feat: title과 정책카드 사이 margin 추가

### DIFF
--- a/src/pages/home/Home.style.js
+++ b/src/pages/home/Home.style.js
@@ -29,7 +29,7 @@ const Title = styled.div`
     rgba(255, 255, 255, 0.7)
   );
   backdrop-filter: blur(4px);
-  color: #53565d;
+  color: var(--color-gray-800);
   font-weight: bold;
   z-index: 3;
   margin-bottom: 10px;

--- a/src/pages/home/Home.style.js
+++ b/src/pages/home/Home.style.js
@@ -32,6 +32,7 @@ const Title = styled.div`
   color: #53565d;
   font-weight: bold;
   z-index: 3;
+  margin-bottom: 10px;
 `;
 
 export { Container, PolicyContainer, Title };


### PR DESCRIPTION
- 이미지 파일명 변경에 따른 이미지 경로 수정
- home 화면 title과 정책 카드 사이 margin 추가

<img width="267" alt="스크린샷 2024-10-30 오후 8 40 24" src="https://github.com/user-attachments/assets/cfee54ef-a384-4a5d-a699-ba53bcc64159">
<img width="267" alt="스크린샷 2024-10-30 오후 8 40 27" src="https://github.com/user-attachments/assets/b42bfa4c-41ec-4be1-ab84-27b1cf61e3d0">
